### PR TITLE
Fixes #33, Updates Troubleshooting, Better Distro Compatibility, Removes webbrowser, Add Progress Counter, Increased Delay

### DIFF
--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -5,7 +5,6 @@ import os
 import sys
 import time
 import json
-import webbrowser
 import vdf
 import requests
 
@@ -304,7 +303,13 @@ def main(args):
 
             # Workaround provided by Valve for the new library
             url = "steam://resetcollections"
-            webbrowser.open(url, new=0, autoraise=True)
+            input("Open steam, then press enter to continue")
+            if sys.platform=="win32":
+                command = "start "
+            else:
+                command = "xdg-open "
+            input("Please launch Steam and then press Enter...")
+            os.system(command + url)
 
 # Run it
 if __name__ == "__main__":

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -231,6 +231,8 @@ def main(args):
     # This makes the code slightly cleaner
     apps = sharedconfig[configstore]["Software"]["Valve"]["Steam"][get_apps_key(sharedconfig, configstore)]
 
+    print("Found {} Steam games".format(len(apps)))
+
     for app_id in apps:
         # This has to be here because some Steam AppID's are strings of text, which ProtonDB does not support. Check test01.vdf line 278 for an example.
         try:

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -234,7 +234,7 @@ def main(args):
     appCount = len(apps)
     print("Found {} Steam games".format(appCount))
 
-    for count, app_id in enumerate(apps):
+    for count, app_id in enumerate(apps, 1):
         # This has to be here because some Steam AppID's are strings of text, which ProtonDB does not support. Check test01.vdf line 278 for an example.
         try:
             int(app_id)

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -306,7 +306,7 @@ def main(args):
 
             # Workaround provided by Valve for the new library
             url = "steam://resetcollections"
-            if sys.platform=="win32":
+            if sys.platform == "win32":
                 command = "start "
             else:
                 command = "xdg-open "

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -305,13 +305,12 @@ def main(args):
 
             # Workaround provided by Valve for the new library
             url = "steam://resetcollections"
-            input("Open steam, then press enter to continue")
             if sys.platform=="win32":
                 command = "start "
             else:
                 command = "xdg-open "
-            input("Please launch Steam and then press Enter...")
-            os.system(command + url)
+            input("Please launch Steam, then press Enter to continue...")
+            os.system(command + url) #Reset Collections
 
 # Run it
 if __name__ == "__main__":

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -48,8 +48,8 @@ def is_native(app_id):
     # https://www.reddit.com/r/linux_gaming/comments/bxqsvs/protondb_to_steam_library_tool/eqal68r/
     api_url = "https://store.steampowered.com/api/appdetails?appids={}&filters=platforms".format(app_id)
     steam_api_result = requests.get(api_url)
-    # Wait 1 second before continuing, as Steam only allows 10 requests per 10 seconds, otherwise you get rate limited for a few minutes.
-    time.sleep(1)
+    # Wait 1.3 seconds before continuing, as Steam only allows 10 requests per 10 seconds, otherwise you get rate limited for a few minutes.
+    time.sleep(1.3)
 
     if steam_api_result.status_code != 200:
         print("Error pulling info from Steam API for {}. You're probably being rate-limited or the store page no longer exists.".format(app_id))

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -231,9 +231,10 @@ def main(args):
     # This makes the code slightly cleaner
     apps = sharedconfig[configstore]["Software"]["Valve"]["Steam"][get_apps_key(sharedconfig, configstore)]
 
-    print("Found {} Steam games".format(len(apps)))
+    appCount = len(apps)
+    print("Found {} Steam games".format(appCount))
 
-    for app_id in apps:
+    for count, app_id in enumerate(apps):
         # This has to be here because some Steam AppID's are strings of text, which ProtonDB does not support. Check test01.vdf line 278 for an example.
         try:
             int(app_id)
@@ -281,7 +282,7 @@ def main(args):
             if old_key == protondb_rating:
                 new_rank = False
             else:
-                print("{} {} => {}".format(app_id, old_key, protondb_rating))
+                print("{} {} => {} ({} of {})".format(app_id, old_key, protondb_rating, count, appCount))
         # If it throws a key error it is a new game to rank
         except KeyError:
             print("{} {}".format(app_id, protondb_rating))

--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ If you would like to make a PR all I ask is that you are also open to feedback o
 ### Troubleshooting
 
 If you are finding that only some of your Proton compatible games are being categorized try this:
-1. Select all of the games in your library
-2. Right click -> Set Categories...
-3. Add some random category to them all (you can remove this later)
-4. Close Steam to force it to write all of your games to the sharedconfig.vdf file
-5. Try running the script again
+1. Select all of the uncategorized games in your library
+2. Right click -> Add to -> ProtonDB Ranking: 7 Borked
+3. File -> Exit Steam to force it to write all of your games to the sharedconfig.vdf file
+4. Try running the script again
 
 Please keep in mind that most Linux Native games will not be categorized without the `--check-native` flag, as ProtonDB doesn't return anything for them.
 


### PR DESCRIPTION
1. Improved calling Python from Linux so it always works regardless of where Python is stored, using env.
2. I experienced a random chromium window popup, which was intended to do a collection reset, I later learned. I replaced this with a direct call that goes to steam in both linux and windows, and removed the no longer used webbrowser library. This uses xdg-open in linux and start in windows.
Fixes #33 
3. Added a count of how many games the script is actually finding
4. Updated troubleshooting steps to what actually was working for me, which may also be related to 33, but this definitely works for all games
5. Added a (X of X) type count for each game, to keep track of how far you are in updating your list
6. Changed the delay on steam native requests from 1s to 1.3s because I experienced limiting when using 1s on my connection speed