### PR TITLE
Release 1.2.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Run pylint
       run: |
-        pylint *.py **/*.py --disable=invalid-name,bare-except,too-many-branches,too-many-locals
+        pylint *.py **/*.py --disable=invalid-name,bare-except,too-many-branches,too-many-locals,too-many-statements
     
     - name: Run test cases
       run: |

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -303,7 +303,8 @@ def main(args) -> None:
     cache_manager.save_caches()
     end_time = time.time() - start_time
 
-    print(f"Took {end_time} to process, average of {end_time / app_count} per game")
+    print(f"Took a total of {round(end_time, 2)} seconds to process, " + \
+        f"with an average of {round(end_time / app_count, 2)} seconds per game")
 
     # True if -n or --no-save is passed
     if not args.no_save:

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -57,6 +57,10 @@ def is_native(app_id: str, skip_cache: bool, cache_manager: CacheManager) -> boo
             is_native_game = linux_support in ["True", "true", True]
 
         cache_manager.add_to_steam_native_cache(app_id, is_native_game)
+    else:
+        # give a 1 day cooldown to reduce server load and speed when retrying after a long run
+        cache_manager.add_to_steam_native_cache(app_id, is_native_game, 1, 0)
+
     return is_native_game
 
 
@@ -174,6 +178,9 @@ def get_protondb_rating(app_id: str, skip_cache: bool, cache_manager: CacheManag
             protondb_ranking = protondb_data["trendingTier"]
 
         cache_manager.add_to_protondb_cache(app_id, protondb_ranking)
+    else:
+        # give a 1 day cooldown to reduce server load and speed when retrying after a long run
+        cache_manager.add_to_protondb_cache(app_id, protondb_ranking, 1, 0)
 
     return protondb_ranking
 

--- a/ProtonDB-Tags.py
+++ b/ProtonDB-Tags.py
@@ -29,7 +29,7 @@ def is_native(app_id: str, skip_cache: bool, cache_manager: CacheManager) -> boo
     is_native_game = False
 
     try:
-        steam_response = requests.get(api_url)
+        steam_response = requests.get(api_url, timeout=3)
     except requests.Timeout:
         print(f"{app_id} | Timed out reading Steam store page.")
     except requests.ConnectionError:
@@ -103,7 +103,7 @@ def get_apps_list(sharedconfig: dict, fetch_games: bool) -> dict:
             "&include_free_sub=true" + \
             "&format=json"
 
-        get_owned_games_result = requests.get(api_url)
+        get_owned_games_result = requests.get(api_url, timeout=3)
         if get_owned_games_result.status_code != 200:
             print("There was a problem retreiving your games list from the Steam API, " + \
                 f"status code was: {get_owned_games_result.status_code}")
@@ -160,7 +160,7 @@ def get_protondb_rating(app_id: str, skip_cache: bool, cache_manager: CacheManag
     protondb_ranking = "unrated"
 
     try:
-        protondb_response = requests.get(api_url)
+        protondb_response = requests.get(api_url, timeout=3)
     except requests.Timeout:
         print(f"{app_id} | Timed out reading the ranking from ProtonDB")
     except requests.ConnectionError:
@@ -226,6 +226,8 @@ def main(args) -> None:
     app_count = len(apps)
 
     print(f"\nFound a total of {app_count} Steam games.")
+    start_time = time.time()
+
     for count, app_id in enumerate(apps, 1):
         # This has to be here because some Steam AppID's are strings of text,
         # which ProtonDB does not support. Check test01.vdf line 278 for an example.
@@ -292,6 +294,9 @@ def main(args) -> None:
             cache_manager.save_caches() # Save every once in awhile
 
     cache_manager.save_caches()
+    end_time = time.time() - start_time
+
+    print(f"Took {end_time} to process, average of {end_time / app_count} per game")
 
     # True if -n or --no-save is passed
     if not args.no_save:

--- a/Utils/CacheManager.py
+++ b/Utils/CacheManager.py
@@ -92,7 +92,8 @@ class CacheManager:
         return (found_in_cache, value)
 
 
-    def add_to_steam_native_cache(self, app_id: str, value: bool, days:int = 7, offset:int = 7) -> None:
+    def add_to_steam_native_cache(self, app_id: str, value: bool, days:int = 7, offset:int = 7) \
+        -> None:
         '''Adds the specified value to the Steam native cache,
            sets expiration to (7 days + random value 0-7 days).'''
 
@@ -100,7 +101,9 @@ class CacheManager:
 
         # 86400 = seconds in 1 day
         # 604800 = seconds in 7 days
-        app_cache["time_to_check"] = int(time.time()) + (86400 * days) + random.randint(0, (86400 * offset))
+        app_cache["time_to_check"] = int(time.time()) + (86400 * days) \
+            + random.randint(0, (86400 * offset))
+
         app_cache["value"] = value
 
 
@@ -129,7 +132,9 @@ class CacheManager:
 
         # 86400 = seconds in 1 day
         # 604800 = seconds in 7 days
-        app_cache["time_to_check"] = int(time.time()) + (86400 * days) + random.randint(0, (86400 * offset))
+        app_cache["time_to_check"] = int(time.time()) + (86400 * days) \
+            + random.randint(0, (86400 * offset))
+            
         app_cache["value"] = value
 
 

--- a/Utils/CacheManager.py
+++ b/Utils/CacheManager.py
@@ -134,7 +134,7 @@ class CacheManager:
         # 604800 = seconds in 7 days
         app_cache["time_to_check"] = int(time.time()) + (86400 * days) \
             + random.randint(0, (86400 * offset))
-            
+
         app_cache["value"] = value
 
 

--- a/Utils/CacheManager.py
+++ b/Utils/CacheManager.py
@@ -44,7 +44,7 @@ class CacheManager:
 
 
     def __init__(self):
-        '''Init'''
+        '''Init, loads or creates the cache if not found.'''
 
         self._base_cache_path = self._get_cache_path()
         self._steam_native_cache_path = os.path.join(self._base_cache_path, "steamNativeCache.json")
@@ -53,15 +53,23 @@ class CacheManager:
         self._protondb_cache = {}
 
         if os.path.exists(self._steam_native_cache_path):
-            with open(self._steam_native_cache_path, encoding="utf-8") as cache_json:
-                self._steam_native_cache = json.load(cache_json)
+            try:
+                with open(self._steam_native_cache_path, encoding="utf-8") as cache_json:
+                    self._steam_native_cache = json.load(cache_json)
+            except json.JSONDecodeError:
+                print("Error reading Steam native cache, creating a new one...")
+                self._steam_native_cache = {}
         else:
             print("\nSteam native cache not found.")
             print(f"This will be created here: {self._steam_native_cache_path}")
 
         if os.path.exists(self._protondb_cache_path):
-            with open(self._protondb_cache_path, encoding="utf-8") as cache_json:
-                self._protondb_cache = json.load(cache_json)
+            try:
+                with open(self._protondb_cache_path, encoding="utf-8") as cache_json:
+                    self._protondb_cache = json.load(cache_json)
+            except json.JSONDecodeError:
+                print("Error reading ProtonDB cache, creating a new one...")
+                self._protondb_cache = {}
         else:
             print("\nProtonDB cache not found.")
             print(f"This will be created here: {self._protondb_cache_path}")

--- a/Utils/CacheManager.py
+++ b/Utils/CacheManager.py
@@ -92,15 +92,15 @@ class CacheManager:
         return (found_in_cache, value)
 
 
-    def add_to_steam_native_cache(self, app_id: str, value: bool) -> None:
+    def add_to_steam_native_cache(self, app_id: str, value: bool, days:int = 7, offset:int = 7) -> None:
         '''Adds the specified value to the Steam native cache,
-           sets expiration to (7 days + random value 1-7 days).'''
+           sets expiration to (7 days + random value 0-7 days).'''
 
         self._steam_native_cache[app_id] = app_cache = {}
 
         # 86400 = seconds in 1 day
         # 604800 = seconds in 7 days
-        app_cache["time_to_check"] = int(time.time()) + 604800 + random.randint(86400, 604800)
+        app_cache["time_to_check"] = int(time.time()) + (86400 * days) + random.randint(0, (86400 * offset))
         app_cache["value"] = value
 
 
@@ -121,15 +121,15 @@ class CacheManager:
         return (found_in_cache, value)
 
 
-    def add_to_protondb_cache(self, app_id: str, value: str) -> None:
+    def add_to_protondb_cache(self, app_id: str, value: str, days:int = 7, offset:int = 7) -> None:
         '''Adds the specified value to the ProtonDB cache,
-           sets expiration to (7 days + random value 1-7 days).'''
+           sets expiration to (7 days + random value 0-7 days).'''
 
         self._protondb_cache[app_id] = app_cache = {}
 
         # 86400 = seconds in 1 day
         # 604800 = seconds in 7 days
-        app_cache["time_to_check"] = int(time.time()) + 604800 + random.randint(86400, 604800)
+        app_cache["time_to_check"] = int(time.time()) + (86400 * days) + random.randint(0, (86400 * offset))
         app_cache["value"] = value
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pylint==2.14.4
+pylint==2.15.3
 requests==2.28.1
 vdf==3.4


### PR DESCRIPTION
Changes:
- Fixes #52 
- Improved caching logic around failed requests. Caches failed responses for 1 day to reduce server load on ProtonDB and Steam, making it faster to run after stopping a long-running check. In my testing, this reduced a 9000+ game library from over an hour to just a couple of minutes.
- Adds a 3 second timeout to all requests, since by default there is no timeout for requests the script would wait indefinitely for a response that would never come. The exact timeout period may change in the future, this seemed like a good value to me for now though.
- Add a time taken output at the end of the script to give some more info to the user. This should make it easier to spot when regressions that make it take longer happen as well.
- Add a user agent to the script to allow ProtonDB and Steam to measure the traffic that is generated on their servers by this script.